### PR TITLE
Feature add error boundary

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
     "react-app-polyfill": "^1.0.6",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.1.2"
+  },
+  "peerDependencies": {
+    "create-react-app": "4.0.0"
   }
 }

--- a/template/src/app.jsx
+++ b/template/src/app.jsx
@@ -3,9 +3,12 @@ import React from 'react';
 import { Router } from './routes';
 import { routeConfig } from './route-components';
 import './index.scss';
+import { ErrorBoundary } from './common/error-boundary';
 
 const App = () => (
-  <Router routeConfig={routeConfig} />
+  <ErrorBoundary>
+    <Router routeConfig={routeConfig} />
+  </ErrorBoundary>
 );
 
 export { App };

--- a/template/src/common/error-boundary/error-boundary.jsx
+++ b/template/src/common/error-boundary/error-boundary.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { logger } from '../../helpers/logger';
+import { UnexpectedError } from '../../pages/unexpected-error';
+
+const IPropTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.element,
+  ]).isRequired,
+};
+
+/*
+  NOTE: remember that error boundaries do not catch
+  all kinds of errors: https://reactjs.org/docs/error-boundaries.html#introducing-error-boundaries
+*/
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  componentDidMount() {
+    // Catch unhandled Promise rejections
+    window.addEventListener('unhandledrejection', (event) => {
+      // Unhandled rejections do not necessarily indicate a crash
+      // of the whole application, so there's no immediate need
+      // to show a fallback UI.
+      logger.warn(`Unhandled Promise rejection: ${event.reason}`);
+      logger.error(event.reason);
+    });
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error) {
+    logger.log(error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <UnexpectedError />;
+    }
+
+    return this.props.children;
+  }
+}
+
+ErrorBoundary.propTypes = IPropTypes;
+
+export { ErrorBoundary };

--- a/template/src/common/error-boundary/error-boundary.test.js
+++ b/template/src/common/error-boundary/error-boundary.test.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+
+import { ErrorBoundary } from './error-boundary';
+import { UnexpectedError } from '../../pages/unexpected-error';
+
+describe('ErrorBoundary', () => {
+  describe('when rendered without errors', () => {
+    const setupTest = (children) => {
+      const listenerSpy = jest.spyOn(window, 'addEventListener')
+        .mockImplementationOnce(() => {});
+      const subject = shallow(
+        <ErrorBoundary>
+          {children}
+        </ErrorBoundary>,
+      );
+
+      return {
+        subject,
+        listenerSpy,
+      };
+    };
+
+    it('must render its children', () => {
+      const children = 'This is a text';
+      const { subject } = setupTest(children);
+
+      expect(subject.text()).toEqual(children);
+    });
+
+    it('must setup an event listener once', () => {
+      const { listenerSpy } = setupTest('Children');
+
+      expect(listenerSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('must setup an event listener for unhandled rejections', () => {
+      const { listenerSpy } = setupTest('Children');
+
+      // We just need to check the first parameter here, that's why
+      // `toHaveBeenCalledWith` is not used, since we don't have access
+      // to the exact handler function passed.
+      expect(listenerSpy.mock.calls[0][0]).toEqual('unhandledrejection');
+    });
+
+    it('must pass a handler to react to the event', () => {
+      const { listenerSpy } = setupTest('Children');
+
+      expect(listenerSpy.mock.calls[0][1]).toBeInstanceOf(Function);
+    });
+  });
+
+  describe('when an error is thrown on a child', () => {
+    const ProblematicComponent = () => {
+      throw new Error('The component has crashed');
+    };
+
+    const setupTest = () => {
+      // NOTE: The error boundary calls console.error with a very big stack
+      // This makes reading test output hard even when all tests pass.
+      // This mock silences the console just for this test.
+      const consoleSpy = jest.spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const subject = mount(
+        <ErrorBoundary>
+          <ProblematicComponent />
+        </ErrorBoundary>,
+      );
+      // Restore the console after the error has been caught
+      consoleSpy.mockRestore();
+
+      return subject;
+    };
+
+    it('calls componentDidCatch only once', () => {
+      const spy = jest.spyOn(ErrorBoundary.prototype, 'componentDidCatch');
+      setupTest();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders UnexpectedError', () => {
+      const subject = setupTest();
+
+      expect(subject.find(UnexpectedError).length).toEqual(1);
+    });
+  });
+});

--- a/template/src/common/error-boundary/index.js
+++ b/template/src/common/error-boundary/index.js
@@ -1,0 +1,1 @@
+export { ErrorBoundary } from './error-boundary';

--- a/template/src/pages/unexpected-error/index.js
+++ b/template/src/pages/unexpected-error/index.js
@@ -1,0 +1,1 @@
+export { UnexpectedError } from './unexpected-error';

--- a/template/src/pages/unexpected-error/unexpected-error.jsx
+++ b/template/src/pages/unexpected-error/unexpected-error.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+// TODO: Implement this component
+const UnexpectedError = () => (
+  <>
+    <h1>An unexpected error has occured.</h1>
+  </>
+);
+
+export { UnexpectedError };


### PR DESCRIPTION
This PR introduces an error boundary that will:

* Catch any errors thrown in the component flow (but not errors that are thrown on handlers).
* Catch any unhandled promise rejections and log them.