### PR TITLE
bumps CRA version to 4.0.1 from 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "react-router-dom": "^5.1.2"
   },
   "peerDependencies": {
-    "create-react-app": "4.0.0"
+    "create-react-app": "4.0.1"
   }
 }


### PR DESCRIPTION
## Ticket/Card

No ticket for this task.

## Type of change

* [ ] Fix
* [ ] Story
* [x] Chore

## Description of the change

In order to keep up with Create React App we need to update the peer dependency each time a new version releases. Before doing so we need to check the new release of CRA and fix any compatibility issues. Since we're bumping from 4.0.0 to 4.0.1 there are no breaking changes and no updates needed to the project. I've simply updated the peer dependency to reflect that this new version has been checked.