### PR TITLE
Add react-router types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/node": "^16.9.2",
     "@types/react": "^18.0.5",
     "@types/react-dom": "^18.0.1",
+    "@types/react-router": "^5.1.18",
     "@types/react-router-dom": "^5.3.3",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "@typescript-eslint/parser": "^5.20.0",

--- a/template.json
+++ b/template.json
@@ -8,6 +8,7 @@
       "@types/node": "^16.9.2",
       "@types/react": "^18.0.5",
       "@types/react-dom": "^18.0.1",
+      "@types/react-router": "^5.1.18",
       "@types/react-router-dom": "^5.3.3",
       "@typescript-eslint/eslint-plugin": "^5.20.0",
       "@typescript-eslint/parser": "^5.20.0",


### PR DESCRIPTION
## Type of change

* [ ] Fix
* [ ] Story
* [X] Chore

## Description of the change

- Adding the react-router types dependency that solves the following problem:

```TS2769: No overload matches this call.
  Overload 1 of 2, '(props: RouterProps | Readonly<RouterProps>): Router', gave the following error.
    Type '{ children: Element; history: History<unknown>; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Router> & Readonly<RouterProps>'.
      Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Router> & Readonly<RouterProps>'.
  Overload 2 of 2, '(props: RouterProps, context: any): Router', gave the following error.
    Type '{ children: Element; history: History<unknown>; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Router> & Readonly<RouterProps>'.
      Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Router> & Readonly<RouterProps>'.
    37 | // @ts-ignore
    38 | const Router = (props: RouterProps) => (
  > 39 |   <VendorRouter history={history}>
       |    ^^^^^^^^^^^^
    40 |     <ScrollToTop>
    41 |       <Switch>
    42 |         {renderRoutes(props.routeConfig)}
Failed to compile.
```