### PR TITLE
feat: improve typing for route params

### DIFF
--- a/template/src/routes/app-link.tsx
+++ b/template/src/routes/app-link.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 
 import { getRouteFor, Params } from './route-helpers';
-import { RouteName } from './routes';
+import type { RouteName, RouteParams } from './routes';
 
 /*
   This component is a wrapper for linking across and inside apps.
@@ -14,12 +14,13 @@ import { RouteName } from './routes';
   defined in this project. To link outside, use <a></a> tags as usual.
 */
 
-type AppLinkProps = {
+// Extract pathParams from the routeName
+type AppLinkProps<R extends RouteName> = {
   children: React.ReactNode,
   className?: string,
-  pathParams?: Params,
+  pathParams?: RouteParams[R],
   queryParams?: Params,
-  routeName: RouteName,
+  routeName: R,
   targetBlank?: boolean,
 };
 
@@ -30,7 +31,7 @@ const defaultProps = {
   targetBlank: false,
 };
 
-const AppLink = (props: AppLinkProps) => {
+const AppLink = <R extends RouteName>(props: AppLinkProps<R>) => {
   const routePath = getRouteFor(props.routeName, props.pathParams, props.queryParams);
   let targetBlankProps = {};
   if (props.targetBlank) {

--- a/template/src/routes/app-redirect.tsx
+++ b/template/src/routes/app-redirect.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { goToPage, Params } from './route-helpers';
-import { RouteName } from './routes';
+import type { RouteName, RouteParams } from './routes';
 
 /*
   This component is a wrapper for redirecting across and inside apps.
@@ -13,10 +13,10 @@ import { RouteName } from './routes';
   defined in this project. To link outside, use <a></a> tags as usual.
 */
 
-type AppRedirectProps = {
-  pathParams?: Params,
+type AppRedirectProps<R extends RouteName> = {
+  pathParams?: RouteParams[R],
   queryParams?: Params,
-  routeName: RouteName,
+  routeName: R,
 };
 
 const defaultProps = {
@@ -24,7 +24,7 @@ const defaultProps = {
   queryParams: {},
 };
 
-const AppRedirect : React.FC<AppRedirectProps> = (props) => {
+const AppRedirect = <R extends RouteName>(props: AppRedirectProps<R>) => {
   useEffect(() => {
     goToPage(props.routeName, props.pathParams, props.queryParams);
   }, []);

--- a/template/src/routes/routes.ts
+++ b/template/src/routes/routes.ts
@@ -2,6 +2,8 @@
 import { Home } from 'pages/home';
 import { About } from 'pages/about';
 import { NotFound } from 'pages/not-found';
+import type { ExtractRouteParams } from 'react-router';
+import type { Params } from './route-helpers';
 import { Route, setPathParams } from './utils';
 
 export enum RouteName {
@@ -10,10 +12,15 @@ export enum RouteName {
   NotFound = 'notFound',
 }
 
+export interface RouteParams {
+  [key: string]: Params;
+  [RouteName.Home]: ExtractRouteParams<'/:page?'>;
+}
+
 export const routes: Route[] = [
   {
     name: RouteName.Home,
-    path: '/',
+    path: '/:page?',
     exact: true,
     component: Home,
   },

--- a/template/src/routes/routes.ts
+++ b/template/src/routes/routes.ts
@@ -4,7 +4,7 @@ import { About } from 'pages/about';
 import { NotFound } from 'pages/not-found';
 import type { ExtractRouteParams } from 'react-router';
 import type { Params } from './route-helpers';
-import { Route, setPathParams } from './utils';
+import { setPathParams } from './utils';
 
 export enum RouteName {
   Home = 'home',
@@ -12,12 +12,7 @@ export enum RouteName {
   NotFound = 'notFound',
 }
 
-export interface RouteParams {
-  [key: string]: Params;
-  [RouteName.Home]: ExtractRouteParams<'/:page?'>;
-}
-
-export const routes: Route[] = [
+const ROUTES = [
   {
     name: RouteName.Home,
     path: '/:page?',
@@ -35,4 +30,14 @@ export const routes: Route[] = [
     path: '*',
     component: NotFound,
   },
-].map(setPathParams);
+] as const;
+
+/*
+* This type is used to extract the type of the route params
+* from the path string.
+*/
+export type RouteParams = {
+  [K in RouteName]: ExtractRouteParams<Extract<typeof ROUTES[number], { name: K }>['path']>;
+} & Params;
+
+export const routes = ROUTES.map(setPathParams);


### PR DESCRIPTION
The intention of this change is to improve Typing when using the components `<AppLink>` and `<AppRedirect>`.

With this typing in place once you use for example `<AppLink routeName={RouteName.Home}>` this route will have the `pathParams` type mapped from the `routes.ts` file. Typing will immediately infer those types like this once you use the `pathParams` attribute.

```ts
// routes.ts

// ....

const ROUTES = [
  {
    name: RouteName.Home,
    path: '/:page?',
    exact: true,
    component: Home,
  },

// ...
```

![image](https://user-images.githubusercontent.com/1578540/206497343-f7201a42-25be-41b6-8c68-bec31c523b95.png)

---

If for example instead of making the `page` param optional, you put it as required by removing the `?`

```ts
{
    // ...
    path: '/:page',
    // ...
}
```

The typing system will detect that and ask for the required param for this route:

![image](https://user-images.githubusercontent.com/1578540/206497802-a6d4a35f-12e3-4749-9c70-075749723633.png)

---

Now, let's say I add some params for the `/about` route:

```ts
[
  // ...
  {
    name: RouteName.About,
    path: '/about/:id',
    exact: true,
    component: About,
  },
  // ...
]
```

This means that now if you pass a routeName of `RouteName.About` to either `<AppLink>` or `<AppRedirect>` you will see automatically the params for that specific route:

![image](https://user-images.githubusercontent.com/1578540/206498843-d629ae9c-fe9f-43d5-8bfe-ef517b233d9d.png)
